### PR TITLE
Added filter that removes 'Options' where 'Service' is not set in the…

### DIFF
--- a/src/FedEx/Service.php
+++ b/src/FedEx/Service.php
@@ -811,7 +811,9 @@ EOD;
                 $services = [$services];
             }
 
-            return (new Collection($services))->map(function (array $service): string {
+            return (new Collection($services))->filter(function (array $service) {
+                return isset( $service['Service'] );
+            })->map(function (array $service): string {
                 return $service['Service'];
             })->value();
         });


### PR DESCRIPTION
This PR fixes a bug that was caused by FedEx responding with options that were missing some properties. Since we tried to return one of the missing properties this caused the service to throw an Exception. This was solved with a filter that removes the options that don't have the required properties.